### PR TITLE
Use getDisplayTitle() instead of QuickCopy to generate display text

### DIFF
--- a/preventduplicates/chrome/content/preventduplicates/preventDuplicates.js
+++ b/preventduplicates/chrome/content/preventduplicates/preventDuplicates.js
@@ -6,7 +6,7 @@ Zotero.PreventDuplicates = {
 		var params = {"dataIn": null, "dataOut": null};
 		
 		if (item != null) {
-			params["dataIn"] = {"text": Zotero.QuickCopy.getContentFromItems([item],Zotero.Prefs.get("export.quickCopy.setting"))["text"]};
+			params["dataIn"] = {"text": item.getDisplayTitle(true)};
 		}
 		var wm = Components.classes["@mozilla.org/appshell/window-mediator;1"]
                         .getService(Components.interfaces.nsIWindowMediator);


### PR DESCRIPTION
The item's getDisplayTitle() function is used to generate the item description in the native translation progress display, and should address the oddness noted by adamsmith.
