### PR TITLE
Add stylesheets from translation progress popup

### DIFF
--- a/preventduplicates/chrome/content/preventduplicates/dialog.xul
+++ b/preventduplicates/chrome/content/preventduplicates/dialog.xul
@@ -1,4 +1,6 @@
 <?xml version="1.0"?>
+<?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
+<?xml-stylesheet href="chrome://zotero/skin/zotero.css" type="text/css"?>
 <?xml-stylesheet href="chrome://preventduplicates/skin/dialog.css" type="text/css"?>
 <!DOCTYPE window SYSTEM "chrome://preventduplicates/locale/prevent.dtd">
 <dialog xmlns:html="http://www.w3.org/1999/xhtml"


### PR DESCRIPTION
Adding the stylesheets from the Zotero translation progress box clears up the transparency and font jaggies issues shown in adamsmith's screenshot.
